### PR TITLE
Add ability to give custom path

### DIFF
--- a/build-Index.ps1
+++ b/build-Index.ps1
@@ -1,7 +1,9 @@
 param(
-    [string]$title = $env:pagetext
+    [string]$title = $env:pageText,
+    [switch]$useCustomPath = [bool]::Parse($env:useCustomPath),
+    [string]$customPath = $env:customPath
 )
-"<html>
+$html = "<html>
     <head><title>$title</title></head>
     <body>
         <h1>$title</h1>
@@ -9,4 +11,17 @@ param(
         <a href='/hello'>Hello</a><br>
         <a href='/goodbye'>Goodbye</a>
     </body>
-</html>" | Out-File C:\inetpub\wwwroot\index.html -Force
+</html>"
+
+if ($useCustomPath)
+{
+    $path = (Join-Path C:\inetpub\wwwroot $customPath)
+    if (-not (Test-Path $path))
+    {
+        New-Item $path -ItemType Directory
+    }
+    $html | Out-File "$path\index.html" -Force
+}
+else {
+    $html | Out-File C:\inetpub\wwwroot\index.html -Force
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,6 @@ services:
     networks:
       hello:
         aliases:
-          - helloworld
+          - helloworldcustom
 networks:
   hello:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,24 @@ services:
       dockerfile: Dockerfile
     image: estenrye/microsoft-iis-helloworld
     environment:
-      - pagetext=Hello World
+      - pageText=Hello World
     ports:
       - 8090:80
+    networks:
+      hello:
+        aliases:
+          - helloworld
+  helloworld-customPath:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: estenrye/microsoft-iis-helloworld
+    environment:
+      - "pageText=Hello World at /hello"
+      - "useCustomPath=true"
+      - "customPath=hello"
+    ports:
+      - 8091:80
     networks:
       hello:
         aliases:


### PR DESCRIPTION
While testing my loadbalancer proxy redirect container, I discovered that I needed the ability to define the folder path for the hello world site.

These modifications allow me to host the site at /hello or /hello/world by providing two additional environment variables useCustomPath=true and customPath=hello